### PR TITLE
Preserve weights for dynamic queues

### DIFF
--- a/lib/sidekiq/dynamic_queues/fetch.rb
+++ b/lib/sidekiq/dynamic_queues/fetch.rb
@@ -24,8 +24,9 @@ module Sidekiq
           super
         else
           queues = expand_queues(@dynamic_queues)
-          queues = @strictly_ordered_queues ? queues : queues.shuffle
-          queues << "queue:default" if queues.size == 0
+          queues = queues.shuffle if !@strictly_ordered_queues
+          queues << 'default' if queues.empty?
+          queues = queues.uniq.map { |q| "queue:#{q}" }
           queues << TIMEOUT
         end
       end

--- a/lib/sidekiq/dynamic_queues/fetch.rb
+++ b/lib/sidekiq/dynamic_queues/fetch.rb
@@ -23,12 +23,37 @@ module Sidekiq
         if @dynamic_queues.grep(/(^!)|(^@)|(\*)/).size == 0
           super
         else
-          queues = expand_queues(@dynamic_queues)
-          queues = queues.shuffle if !@strictly_ordered_queues
+          expanded = expand_queues(@dynamic_queues)
+          queues = if @strictly_ordered_queues
+                     expanded.keys.uniq
+                   else
+                     weighted_key_shuffle(expanded)
+                   end
           queues << 'default' if queues.empty?
           queues = queues.uniq.map { |q| "queue:#{q}" }
           queues << TIMEOUT
         end
+      end
+
+      def weighted_key_shuffle(queues_hash)
+        queues = []
+        while queues_hash.present?
+          queue = random_key(queues_hash)
+          queues << queue
+          queues_hash = queues_hash.except(queue)
+        end
+        queues
+      end
+
+      def random_key(queues_hash)
+        r = rand(queues_hash.values.sum)
+        sum = 0
+        queues_hash.each do |queue, priority|
+          sum += priority
+          return queue if r < sum
+        end
+        # this would only happen if all priorities are 0
+        queues_hash.keys.first
       end
 
       def self.translate_from_cli(*queues)

--- a/lib/sidekiq/dynamic_queues/server.rb
+++ b/lib/sidekiq/dynamic_queues/server.rb
@@ -26,7 +26,7 @@ module Sidekiq
             view_data = {
                 'name' => k,
                 'value' => Array(v).join(", "),
-                'expanded' => expanded.join(", ")
+                'expanded' => expanded.keys.join(", ")
             }
             @queues << view_data
           end

--- a/lib/sidekiq/dynamic_queues/server.rb
+++ b/lib/sidekiq/dynamic_queues/server.rb
@@ -23,7 +23,6 @@ module Sidekiq
           dqueues = Attr.get_dynamic_queues
           dqueues.each do |k, v|
             expanded = Attr.expand_queues(["@#{k}"])
-            expanded = expanded.collect {|q| q.split(":").last }
             view_data = {
                 'name' => k,
                 'value' => Array(v).join(", "),


### PR DESCRIPTION
When setting at least one dynamic queue, the weights were being ignored.
I solved this by re-expanding each queue to the same size using the least common multiple of the expanded sizes, and then adjusting them by their given weight.